### PR TITLE
Update docker-compose to use the correct network.

### DIFF
--- a/dev/docker-compose.yml
+++ b/dev/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
+      - traefik.docker.network=${ISLE_PROXY_NAME}
       - traefik.enable=true
       - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 

--- a/prod/docker-compose.yml
+++ b/prod/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
+      - traefik.docker.network=${ISLE_PROXY_NAME}
       - traefik.enable=true
       - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 

--- a/stage/docker-compose.yml
+++ b/stage/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - ./logs/apache/httpd:/var/log/apache2
       - ./logs/apache/fits:/var/log/fits
     labels:
-      - traefik.docker.network=${COMPOSE_PROJECT_NAME}_isle-internal
+      - traefik.docker.network=${ISLE_PROXY_NAME}
       - traefik.enable=true
       - "traefik.frontend.rule=Host:${BASE_DOMAIN}; PathPrefix: /, /adore-djatoka, /cantaloupe"
 


### PR DESCRIPTION
Messed up the compose files and included the incorrect network for apache to use as ingress/egress. 
Network = ${ISLE_PROXY_NAME}, not the default for single installs.